### PR TITLE
GPU version contains a critical bug. 

### DIFF
--- a/src/cuda_kernel.cu
+++ b/src/cuda_kernel.cu
@@ -200,9 +200,12 @@ __global__ void lig_vox_elec(int ng1,int na,float grid_width,float *_Charge,floa
     if(id < na) {
         //if(!fabs(_Charge[id]) < 0.0001) continue;
         const int id3 = id * 3;
-        const int   i = (atom_coord_rotated[id3  ] + pad) / grid_width;
-        const int   j = (atom_coord_rotated[id3+1] + pad) / grid_width;
-        const int   k = (atom_coord_rotated[id3+2] + pad) / grid_width;
+        //const int   i = (atom_coord_rotated[id3  ] + pad) / grid_width;
+        //const int   j = (atom_coord_rotated[id3+1] + pad) / grid_width;
+        //const int   k = (atom_coord_rotated[id3+2] + pad) / grid_width;
+        const int   i = FMAX(0, FMIN((atom_coord_rotated[id3  ] + pad) / grid_width, ng1 - 1));
+        const int   j = FMAX(0, FMIN((atom_coord_rotated[id3+1] + pad) / grid_width, ng1 - 1));
+        const int   k = FMAX(0, FMIN((atom_coord_rotated[id3+2] + pad) / grid_width, ng1 - 1));
 
         //grid_i[i*ng2+j*ng1+k] += _Charge[id];
         //printf(" %08d-1 :  %.2f, %.2f\n",i*ng2+j*ng1+k,grid_i[i*ng2+j*ng1+k],_Charge[id]);

--- a/src/fft_process.cpp
+++ b/src/fft_process.cpp
@@ -597,10 +597,11 @@ void FFTProcess::cuda_fft(float *grid_r,float *grid_i,float *grid_coord,float *a
                     for( int k = num_sort-1 ; k > j ; k-- ) {
                         _Select[myid2][k] = _Select[myid2][k-1];
                     }
+                    const int index = top_index_host[myid2][i];
                     _Select[myid2][j].score    = raw;
-                    _Select[myid2][j].index[1] = i / nf2;
-                    _Select[myid2][j].index[2] = (i / _Num_fft) % _Num_fft;
-                    _Select[myid2][j].index[3] = i % _Num_fft;
+                    _Select[myid2][j].index[1] = index / nf2;
+                    _Select[myid2][j].index[2] = (index / _Num_fft) % _Num_fft;
+                    _Select[myid2][j].index[3] = index % _Num_fft;
                     break;
                 }
             }

--- a/src/fft_process.cu
+++ b/src/fft_process.cu
@@ -597,10 +597,11 @@ void FFTProcess::cuda_fft(float *grid_r,float *grid_i,float *grid_coord,float *a
                     for( int k = num_sort-1 ; k > j ; k-- ) {
                         _Select[myid2][k] = _Select[myid2][k-1];
                     }
+                    const int index = top_index_host[myid2][i];
                     _Select[myid2][j].score    = raw;
-                    _Select[myid2][j].index[1] = i / nf2;
-                    _Select[myid2][j].index[2] = (i / _Num_fft) % _Num_fft;
-                    _Select[myid2][j].index[3] = i % _Num_fft;
+                    _Select[myid2][j].index[1] = index / nf2;
+                    _Select[myid2][j].index[2] = (index / _Num_fft) % _Num_fft;
+                    _Select[myid2][j].index[3] = index % _Num_fft;
                     break;
                 }
             }

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -216,9 +216,12 @@ void Ligand::electro(const float &beta,const float &eratio,
     for( int l = 0 ; l < na ; l++ ) { //for each atom, find nearest grid(i,j,k)
         //if(fabs(_Charge[l]) < 0.0001) continue;
         const int l3 = l * 3;
-        const int   i = (atom_coord_rotated[l3  ] + pad) / grid_width;
-        const int   j = (atom_coord_rotated[l3+1] + pad) / grid_width;
-        const int   k = (atom_coord_rotated[l3+2] + pad) / grid_width;
+        //const int   i = (atom_coord_rotated[l3  ] + pad) / grid_width;
+        //const int   j = (atom_coord_rotated[l3+1] + pad) / grid_width;
+        //const int   k = (atom_coord_rotated[l3+2] + pad) / grid_width;
+        const int   i = max(0, min(ng1 - 1, (int) ((atom_coord_rotated[l3  ] + pad) / grid_width)));
+        const int   j = max(0, min(ng1 - 1, (int) ((atom_coord_rotated[l3+1] + pad) / grid_width)));
+        const int   k = max(0, min(ng1 - 1, (int) ((atom_coord_rotated[l3+2] + pad) / grid_width)));
         
         //printf(" [%5d] [x:%12.8f,y:%12.8f,z:%12.8f] [pad:%6.3f], [%3d,%3d,%3d] \n",l,atom_coord_rotated[l3  ],atom_coord_rotated[l3+1],atom_coord_rotated[l3+2],pad,i,j,k);
         //printf(" [%5d] [x:%8.0f,y:%8.0f,z:%8.0f] [pad:%6.3f], [%3d,%3d,%3d] \n",l,atom_coord_rotated[l3  ],atom_coord_rotated[l3+1],atom_coord_rotated[l3+2],pad,i,j,k);


### PR DESCRIPTION
Related to #19 .

Fixed a critical bug and a minor bug:
* Critical bug: The outputs of version 4.1.0, 4.1.1 and 4.1.2 of `megadock-gpu` and `megadock-gpu-dp` outputs was wrong when using `-t` option.
* Minor bug: Mis-indexing sometimes occurs when calculating ligand rotation.