### PR TITLE
Temporary fix to decoygen segmentation fault

### DIFF
--- a/src/decoygen.cpp
+++ b/src/decoygen.cpp
@@ -23,7 +23,7 @@ struct parse_res {
           a1, a2, a3, t1, t2, t3, 
           rand1, rand2, rand3, spacing, score;
     int N;
-    char receptor[100], ligand[100];
+    char receptor[300], ligand[300];
 };
 
 void rotateAtom(float, float, float, float *, float *, float *,


### PR DESCRIPTION
Was getting the error `segmentation fault (core dumped)` while trying to generate decoys, and saw that the length of the receptor/ligand string was hard coded for 100 characters. Since I'm not fluent in C++ the best I can do is suggest an increase in the allowed number of characters for these names (the `megadock` input pdb-file paths).